### PR TITLE
Backend-CeruleanRISC: Implemented Global Var lowering and Fixed bug with loading immediates

### DIFF
--- a/backend/backends/ceruleanrisc/ceruleanVirtualRISCAST.py
+++ b/backend/backends/ceruleanrisc/ceruleanVirtualRISCAST.py
@@ -42,21 +42,22 @@ class Node (ABC):
 
 class ProgramNode (Node):
 
-    def __init__ (self, codeunits, externSymbols=None):
+    def __init__ (self, codeunits, externSymbols=None, globalVars=None):
         self.codeunits = codeunits
         self.externSymbols = externSymbols if externSymbols is not None else []
+        self.globalVars = globalVars if globalVars is not None else []
 
     def accept (self, visitor):
         return visitor.visitProgramNode (self)
 
     def copy (self):
-        node = ProgramNode (None, self.externSymbols[:])
+        node = ProgramNode (None, self.externSymbols[:], self.globalVars[:])
         for codeunit in self.codeunits:
             node.codeunits += [codeunit.copy ()]
         return node
 
     def __repr__ (self):
-        return f"Program({repr (self.codeunits)})"
+        return f"Program({repr (self.codeunits)}, globals={repr(self.globalVars)})"
 
     def __str__ (self):
         return "\n".join ([str (codeunit) for codeunit in self.codeunits])
@@ -361,3 +362,29 @@ class StringLiteralNode (LiteralNode):
 
     def __str__ (self):
         return str (self.value)
+
+# ========================================================================
+
+class GlobalVariableNode (Node):
+    """
+    Represents a global variable declaration in the data section.
+    Global variables are stored in memory (data section) rather than registers.
+    """
+
+    def __init__ (self, id, size=8, initialValue=0):
+        super ().__init__ ()
+        self.id = id
+        self.size = size  # Size in bytes
+        self.initialValue = initialValue
+
+    def accept (self, visitor):
+        return visitor.visitGlobalVariableNode (self)
+
+    def copy (self):
+        return GlobalVariableNode (self.id, self.size, self.initialValue)
+
+    def __repr__ (self):
+        return f"GlobalVar({repr (self.id)}, size={self.size}, init={self.initialValue})"
+
+    def __str__ (self):
+        return f"{self.id}"

--- a/backend/backends/ceruleanrisc/ceruleanVirtualRISCASTVisitor.py
+++ b/backend/backends/ceruleanrisc/ceruleanVirtualRISCASTVisitor.py
@@ -62,3 +62,7 @@ class ASMASTVisitor (ABC):
     @abstractmethod
     def visitStringLiteralNode (self, node):
         pass
+
+    @abstractmethod
+    def visitGlobalVariableNode (self, node):
+        pass

--- a/backend/backends/ceruleanrisc/frameLowering.py
+++ b/backend/backends/ceruleanrisc/frameLowering.py
@@ -63,7 +63,7 @@ class FrameLoweringVisitor(ASMASTVisitor):
             else:
                 processedFunctions.append(function)
         
-        return ASM_AST.ProgramNode(processedFunctions, node.externSymbols)
+        return ASM_AST.ProgramNode(processedFunctions, node.externSymbols, node.globalVars)
     
     def visitFunctionNode(self, node):
         """
@@ -149,6 +149,10 @@ class FrameLoweringVisitor(ASMASTVisitor):
         return node
     
     def visitStringLiteralNode(self, node):
+        return node
+    
+    def visitGlobalVariableNode(self, node):
+        # Global variables are in data section, no frame lowering needed
         return node
 
 # =================================================================================================

--- a/backend/backends/ceruleanrisc/naiveAllocator.py
+++ b/backend/backends/ceruleanrisc/naiveAllocator.py
@@ -73,7 +73,7 @@ class NaiveAllocationVisitor(ASMASTVisitor):
             else:
                 allocatedFunctions.append(function)
         
-        return ASM_AST.ProgramNode(allocatedFunctions, node.externSymbols)
+        return ASM_AST.ProgramNode(allocatedFunctions, node.externSymbols, node.globalVars)
     
     def visitFunctionNode(self, node):
         """
@@ -208,6 +208,10 @@ class NaiveAllocationVisitor(ASMASTVisitor):
         return node
     
     def visitStringLiteralNode(self, node):
+        return node
+    
+    def visitGlobalVariableNode(self, node):
+        # Global variables are in data section, no allocation needed
         return node
 
 # =================================================================================================

--- a/backend/backends/ceruleanrisc/registerAllocator.py
+++ b/backend/backends/ceruleanrisc/registerAllocator.py
@@ -193,7 +193,7 @@ class AllocationVisitor(ASMASTVisitor):
             else:
                 allocatedFunctions.append(function)
         
-        return ASM_AST.ProgramNode(allocatedFunctions, node.externSymbols)
+        return ASM_AST.ProgramNode(allocatedFunctions, node.externSymbols, node.globalVars)
     
     def visitFunctionNode(self, node):
         """
@@ -305,6 +305,10 @@ class AllocationVisitor(ASMASTVisitor):
         return node
     
     def visitStringLiteralNode(self, node):
+        return node
+    
+    def visitGlobalVariableNode(self, node):
+        # Global variables are in data section, no allocation needed
         return node
 
 # =================================================================================================


### PR DESCRIPTION
This implements the translation of Global Variables from IR -> CeruleanRISC.

And this fixes a bug with loading immediates. The lli instruction does not zero/sign extend so the register must be zeroed manually before loading. Ideally the ISA should be updated to easy this (via a zero register) but that is not yet completed.